### PR TITLE
Update to 1.6.0 and add migrations

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,7 +1,7 @@
 #sub_path_only rewrite ^__PATH__$ __PATH__/ permanent;
 location __PATH__/ {
 
-  proxy_pass        http://127.0.0.1:__PORT__;
+  proxy_pass        http://127.0.0.1:__PORT__/;
   proxy_redirect    off;
   proxy_set_header  Host $host;
   proxy_set_header  X-Real-IP $remote_addr;

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -8,7 +8,7 @@ Type=simple
 User=__APP__
 Group=__APP__
 WorkingDirectory=__INSTALL_DIR__/
-ExecStart=__INSTALL_DIR__/shiori serve --port __PORT__ --webroot __PATH__
+ExecStart=__INSTALL_DIR__/shiori server --port __PORT__ --webroot __PATH__
 Restart=always
 Environment="SHIORI_DIR=__DATA_DIR__"
 

--- a/doc/POST_INSTALL.md
+++ b/doc/POST_INSTALL.md
@@ -1,1 +1,1 @@
-The default account is `shiori` with password `gopher`. It is removed once another 'owner' account is created.
+The default account is `shiori` with password `gopher`. Please manually remove it after you create your own account.

--- a/doc/POST_INSTALL_fr.md
+++ b/doc/POST_INSTALL_fr.md
@@ -1,1 +1,1 @@
-Le compte par défaut est `shiori` avec le mot de passe `gopher`. Il est supprimé une fois qu'un autre compte « propriétaire » est créé.
+Le compte par défaut est `shiori` avec le mot de passe `gopher`. Veuillez le supprimer manuellement après avoir créé votre propre compte.

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Shiori"
 description.en = "Simple bookmark manager"
 description.fr = "Gestionnaire de liens simple"
 
-version = "1.5.5~ynh4"
+version = "1.6.0~ynh1"
 
 maintainers = ["eric_G"]
 
@@ -45,12 +45,12 @@ ram.runtime = "50M"
     [resources.sources]
     
         [resources.sources.main]
-        amd64.url = "https://github.com/go-shiori/shiori/releases/download/v1.5.5-rc.2/shiori_Linux_x86_64.tar.gz"
-        amd64.sha256 = "928adfc3d927b718c7bd75396bbb3a34cb542676374b6c89bb3da92063ac099c"
-        arm64.url = "https://github.com/go-shiori/shiori/releases/download/v1.5.5-rc.2/shiori_Linux_aarch64.tar.gz"
-        arm64.sha256 = "98fc7c8114264b338838089a6ab7c4ce326224fac4f498b6ecc4bfab2d3d3c78"
-        armhf.url = "https://github.com/go-shiori/shiori/releases/download/v1.5.5-rc.2/shiori_Linux_arm.tar.gz"
-        armhf.sha256 = "3ac24d434ff7a76bb3a8810e6c23caf28a7040c67756fec99a2483f04a197f77"
+        amd64.url = "https://github.com/go-shiori/shiori/releases/download/v1.6.0/shiori_Linux_x86_64.tar.gz"
+        amd64.sha256 = "3bcc7557db94d8d6d8f8940f9e37412f198c30f520642e817f4b38a6fee1822e"
+        arm64.url = "https://github.com/go-shiori/shiori/releases/download/v1.6.0/shiori_Linux_aarch64.tar.gz"
+        arm64.sha256 = "74add39dc22bd59dcfe467571688cac29dcc85da90d4b7e4ce668182d9081d34"
+        armhf.url = "https://github.com/go-shiori/shiori/releases/download/v1.6.0/shiori_Linux_arm.tar.gz"
+        armhf.sha256 = "55e8ae7136d39b7f09401b87c6e297695dc6efe1bb2b55c119ecaf540fdf4a19"
         in_subdir = false
         autoupdate.strategy = "latest_github_release"
         autoupdate.asset.amd64 = "^shiori_Linux_x86_64.tar.gz$"

--- a/scripts/backup
+++ b/scripts/backup
@@ -25,7 +25,7 @@ ynh_backup --src_path="$install_dir"
 # BACKUP THE APP DATA DIR
 #=================================================
 
-ynh_backup --src_path="$data_dir" --is-big
+ynh_backup --src_path="$data_dir" --is_big
 
 #=================================================
 # BACKUP THE NGINX CONFIGURATION

--- a/scripts/backup
+++ b/scripts/backup
@@ -22,6 +22,12 @@ ynh_print_info --message="Declaring files to be backed up..."
 ynh_backup --src_path="$install_dir"
 
 #=================================================
+# BACKUP THE APP DATA DIR
+#=================================================
+
+ynh_backup --src_path="$data_dir" --is-big
+
+#=================================================
 # BACKUP THE NGINX CONFIGURATION
 #=================================================
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -41,6 +41,39 @@ chown -R $app:www-data "$install_dir"
 chmod +x "$install_dir/shiori"
 
 #=================================================
+# MIGRATE AND UPGRADE
+#=================================================
+
+if [ "$upgrade_type" == "UPGRADE_APP" ]
+then
+	if ynh_compare_current_pacakge_version --comparison lt --version 1.50~ynh9
+	then
+		ynh_script_progression --message="Migrating sqlite from version < 1.50~ynh9..." --weight=1
+		FTS4_EXISTS=$(sqlite3 "$data_dir/shiori.db" "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'bookmark_content' AND sql LIKE '%USING fts4%';")
+		if [ -z "$FTS4_EXISTS" ]
+		then
+			echo "No  FTS4 table found or already migrated"
+		else
+			sqlite3 "$data_dir/shiori.db" "BEGIN TRANSACTION; CREATE VIRTUAL TABLE bookmark_content_fts5 USING fts5(title, content, html, docid); INSERT INTO bookmark_content_fts5 (title, content, html, docid) SELECT title, content, html, docid FROM bookmark_content; DROP TABLE bookmark_content; ALTER TABLE bookmark_content_fts5 RENAME TO bookmark_content; COMMIT;"
+		fi
+
+		SCHEMA_MIGRATIONS_EXISTS=$(sqlite3 "$data_dir/shiori.db"  "SELECT name FROM sqlite_master WHERE type='table' AND name='schema_migrations';")
+		if [ -z "$SCHEMA_MIGRATIONS_EXISTS" ]; then
+			echo "No schema_migrations table found, skipping"
+		else
+			DIRTY=$(sqlite3 "$data_dir/shiori.db" "SELECT dirty FROM schema_migrations WHERE dirty = 1;")
+			if [ -z "$DIRTY" ]; then
+				echo "No dirty migrations found, skipping"
+			else
+				VERSION=$(sqlite3 "$data_dir/shiori.db" "SELECT version FROM schema_migrations WHERE dirty = 1;")
+				NEW_VERSION=$((VERSION - 1))
+				sqlite3 "$data_dir/shiori.db" "UPDATE schema_migrations SET version = $NEW_VERSION, dirty = 0 WHERE dirty = 1;"
+			fi
+		fi
+	fi
+fi
+
+#=================================================
 # REAPPLY SYSTEM CONFIGURATIONS
 #=================================================
 ynh_script_progression --message="Upgrading system configurations related to $app..." --weight=1

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -46,7 +46,7 @@ chmod +x "$install_dir/shiori"
 
 if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
-	if ynh_compare_current_pacakge_version --comparison lt --version 1.50~ynh9
+	if ynh_compare_current_package_version --comparison lt --version 1.50~ynh9
 	then
 		ynh_script_progression --message="Migrating sqlite from version < 1.50~ynh9..." --weight=1
 		FTS4_EXISTS=$(sqlite3 "$data_dir/shiori.db" "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'bookmark_content' AND sql LIKE '%USING fts4%';")


### PR DESCRIPTION
- move from serve to server
- backup data directory
- migrate fts4 to fts5
- mention shiori/gopher being full user
- update sources

## Problem

- Closes #16 and #12 (Although 12 should have already been closed before)

## Solution

- Checks for package installation being older than 1.5.0 and applies sqlite3 migration
- Updated manifest

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
