### PR TITLE
Fix autoupdate

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -55,7 +55,7 @@ ram.runtime = "50M"
         autoupdate.strategy = "latest_github_release"
         autoupdate.asset.amd64 = "^shiori_Linux_x86_64_.*.tar.gz$"
         autoupdate.asset.arm64 = "^shiori_Linux_aarch64_.*.tar.gz$"
-        autoupdate.asset.armhf = "^shiori_Linux_arm.tar_.*.gz$"
+        autoupdate.asset.armhf = "^shiori_Linux_arm_.*.tar.gz$"
 
     [resources.ports]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -53,9 +53,9 @@ ram.runtime = "50M"
         armhf.sha256 = "a952540a9deba17ad2b89a582280086f11c4c8273e6e1a9bab529f02ea6de31b"
         in_subdir = false
         autoupdate.strategy = "latest_github_release"
-        autoupdate.asset.amd64 = "^shiori_Linux_x86_64_*.tar.gz$"
-        autoupdate.asset.arm64 = "^shiori_Linux_aarch64_*.tar.gz$"
-        autoupdate.asset.armhf = "^shiori_Linux_arm.tar_*.gz$"
+        autoupdate.asset.amd64 = "^shiori_Linux_x86_64_.*.tar.gz$"
+        autoupdate.asset.arm64 = "^shiori_Linux_aarch64_.*.tar.gz$"
+        autoupdate.asset.armhf = "^shiori_Linux_arm.tar_.*.gz$"
 
     [resources.ports]
 


### PR DESCRIPTION
## Problem

Autoupdate is failing. See https://paste.yunohost.org/raw/obuximumef

```
Traceback (most recent call last):
  File "/var/www/app_yunohost/apps/tools/autoupdate_app_sources/autoupdate_app_sources.py", line 637, in run_autoupdate_for_multiprocessing
    result = AppAutoUpdater(app).run(edit=edit, commit=commit, pr=pr)
  File "/var/www/app_yunohost/apps/tools/autoupdate_app_sources/autoupdate_app_sources.py", line 233, in run
    update = self.get_source_update(source, infos)
  File "/var/www/app_yunohost/apps/tools/autoupdate_app_sources/autoupdate_app_sources.py", line 387, in get_source_update
    result = self.get_latest_version_and_asset(strategy, asset, autoupdate)
  File "/var/www/app_yunohost/apps/tools/autoupdate_app_sources/autoupdate_app_sources.py", line 518, in get_latest_version_and_asset
    raise RuntimeError(
RuntimeError: No assets matching regex '^shiori_Linux_x86_64_*.tar.gz$' in ['checksums.txt', 'shiori_Darwin_aarch64_1.7.0.tar.gz', 'shiori_Darwin_x86_64_1.7.0.tar.gz', 'shiori_Linux_aarch64_1.7.0.tar.gz', 'shiori_Linux_arm_1.7.0.tar.gz', 'shiori_Linux_x86_64_1.7.0.tar.gz', 'shiori_Windows_x86_64_1.7.0.zip'].
Full release details on https://github.com/go-shiori/shiori/releases/tag/v1.7.0.
```

## Solution

There was a `.` missing before the `*`.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
